### PR TITLE
Disable RPM GPG key checks.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,7 @@
 - name: Install AWS SSM agent
   yum:
     name: https://s3-us-gov-west-1.amazonaws.com/nimbis-platform-public/amazon-ssm-agent.rpm
+    disable_gpg_check: yes
     state: present
 
 - name: Start the AWS SSM agent service


### PR DESCRIPTION
Necessary to install unsigned RPMs on CentOS/RHEL 7.